### PR TITLE
Fixing Markdown syntax for link

### DIFF
--- a/Journey/009/README.md
+++ b/Journey/009/README.md
@@ -22,7 +22,7 @@
 ## Cloud Research
 
 - Understanding the difference between SDK services
-    - [Low-level client] (https://boto3.amazonaws.com/v1/documentation/api/latest/guide/clients.html)
+    - [Low-level client](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/clients.html)
     - [Resource](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html) 
 
 - Difficulty in obtaining the required topic ARN for SNS with Topic Name


### PR DESCRIPTION
There was just a space between the link text and the URL in the Day 9 post, causing the link not to render. Removing the space should fix it.